### PR TITLE
Move definition of alpha a couple of lines earlier in copJoe@score

### DIFF
--- a/R/cop_objects.R
+++ b/R/cop_objects.R
@@ -962,9 +962,9 @@ copJoe <-
 		      l1_h <- log1mexp(-lh) # log(1-h)
 		      lh_l1_h <- lh - l1_h # log(h/(1-h))
 		      b <- rowSums(-l1_u*u.th/(1-u.th))
+		      alpha <- 1/theta
 		      lP <- polyJ(lh_l1_h, alpha, d, method=method, log=TRUE)
 		      k <- 1:d
-		      alpha <- 1/theta
 		      s <- alpha * unlist(lapply(k, function(k.) sum(1/(theta*(1:k.)-1))))
 		      ls <- log(s. + (k-1)*exp(log(b) - l1_h))
 		      l.a.k <- log(Stirling2.all(d)) + lgamma(k-alpha) - lgamma(1-alpha) + ls


### PR DESCRIPTION
Not sure if this was meant to be, but I'm getting an error using `copJoe@score(u = c(.5,.5), theta = 2)`. It seems that the quantity `alpha <- 1/theta` is used before it is actually defined.